### PR TITLE
Railsチュートリアル第12章

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 /yarn-error.log
 
 .byebug_history
+
+/public/uploads/*

--- a/app/assets/javascripts/password_resets.coffee
+++ b/app/assets/javascripts/password_resets.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/password_resets.scss
+++ b/app/assets/stylesheets/password_resets.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the PasswordResets controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,7 @@
+class PasswordResetsController < ApplicationController
+  def new
+  end
+
+  def edit
+  end
+end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,4 +1,7 @@
 class PasswordResetsController < ApplicationController
+  before_action :get_user, only: [:edit, :update]
+  before_action :valid_user, only: [:edit, :update]
+
   def new
     # Do nothing
   end
@@ -18,5 +21,16 @@ class PasswordResetsController < ApplicationController
 
   def edit
     # TODO
+  end
+
+  private
+
+  def get_user
+    @user = User.find_by(email: params[:email])
+  end
+
+  def valid_user
+    return if @user && @user.activated? && @user.authenticated?(:reset, params[:id])
+    redirect_to root_url
   end
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -30,6 +30,7 @@ class PasswordResetsController < ApplicationController
       render 'edit'
     elsif @user.update(user_params)
       log_in @user
+      @user.update(reset_digest: nil)
       flash[:success] = 'Password has been reset.'
       redirect_to @user
     else

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,7 +1,22 @@
 class PasswordResetsController < ApplicationController
   def new
+    # Do nothing
+  end
+
+  def create
+    @user = User.find_by(email: params[:password_reset][:email].downcase)
+    if @user
+      @user.create_reset_digest
+      @user.send_password_reset_email
+      flash[:info] = 'Email sent with password reset instructions'
+      redirect_to root_url
+    else
+      flash.now[:danger] = 'Email address not found'
+      render 'new'
+    end
   end
 
   def edit
+    # TODO
   end
 end

--- a/app/helpers/password_resets_helper.rb
+++ b/app/helpers/password_resets_helper.rb
@@ -1,0 +1,2 @@
+module PasswordResetsHelper
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,9 +4,8 @@ class UserMailer < ApplicationMailer
     mail to: user.email, subject: 'Account activation'
   end
 
-  def password_reset
-    @greeting = 'Hi'
-
-    mail to: 'to@example.org'
+  def password_reset(user)
+    @user = user
+    mail to: user.email, subject: 'Password reset'
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,6 +56,10 @@ class User < ApplicationRecord
     UserMailer.password_reset(self).deliver_now
   end
 
+  def password_reset_expired?
+    reset_sent_at < 2.hours.ago
+  end
+
   private
 
   def downcase_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  attr_accessor :remember_token, :activation_token
+  attr_accessor :remember_token, :activation_token, :reset_token
   before_save :downcase_email
   before_create :create_activation_digest
   validates :name, presence: true, length: { maximum: 50 }
@@ -45,6 +45,15 @@ class User < ApplicationRecord
 
   def send_activation_email
     UserMailer.account_activation(self).deliver_now
+  end
+
+  def create_reset_digest
+    self.reset_token = User.new_token
+    update(reset_digest: User.digest(reset_token), reset_sent_at: Time.zone.now)
+  end
+
+  def send_password_reset_email
+    UserMailer.password_reset(self).deliver_now
   end
 
   private

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#edit</h1>
+<p>Find me in app/views/password_resets/edit.html.erb</p>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,2 +1,20 @@
-<h1>PasswordResets#edit</h1>
-<p>Find me in app/views/password_resets/edit.html.erb</p>
+<% provide(:title, 'Reset password') %>
+<h1>Reset password</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(@user, url: password_reset_path(params[:id])) do |f| %>
+      <%= render 'shared/error_messages' %>
+
+      <%= hidden_field_tag :email, @user.email %>
+
+      <%= f.label :password %>
+      <%= f.password_field :password, class: 'form-control' %>
+
+      <%= f.label :password_confirmation, "Confirmation" %>
+      <%= f.password_field :password_confirmation, class: 'form-control' %>
+
+      <%= f.submit "Update password", class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#new</h1>
+<p>Find me in app/views/password_resets/new.html.erb</p>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,2 +1,13 @@
-<h1>PasswordResets#new</h1>
-<p>Find me in app/views/password_resets/new.html.erb</p>
+<% provide(:title, "Forgot password") %>
+<h1>Forgot password</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(:password_reset, url: password_resets_path) do |f| %>
+      <%= f.label :email %>
+      <%= f.email_field :email, class: 'form-control' %>
+
+      <%= f.submit "Submit", class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -9,6 +9,7 @@
       <%= f.email_field :email, class: 'form-control' %>
 
       <%= f.label :password %>
+      <%= link_to "(forgot password)", new_password_reset_path %>
       <%= f.password_field :password, class: 'form-control' %>
 
       <%= f.label :remember_me, class: "checkbox inline" do %>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,5 +1,13 @@
-<h1>User#password_reset</h1>
+<h1>Password reset</h1>
+
+<p>To reset your password click the link below:</p>
+
+<%= link_to "Reset password", edit_password_reset_url(@user.reset_token,
+                                                      email: @user.email) %>
+
+<p>This link will expire in two hours.</p>
 
 <p>
-  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
+If you did not request your password to be reset, please ignore this email and
+your password will stay as it is.
 </p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,3 +1,8 @@
-User#password_reset
+To reset your password click the link below:
 
-<%= @greeting %>, find me in app/views/user_mailer/password_reset.text.erb
+<%= edit_password_reset_url(@user.reset_token, email: @user.email) %>
+
+This link will expire in two hours.
+
+If you did not request your password to be reset, please ignore this email and
+your password will stay as it is.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,5 @@ Rails.application.routes.draw do
   delete '/logout', to: 'sessions#destroy'
   resources :users
   resources :account_activations, only: [:edit]
+  resources :password_resets, only: [:new, :create, :edit, :update]
 end

--- a/db/migrate/20190708085151_add_reset_to_users.rb
+++ b/db/migrate/20190708085151_add_reset_to_users.rb
@@ -1,0 +1,6 @@
+class AddResetToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :reset_digest, :string
+    add_column :users, :reset_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190705080317) do
+ActiveRecord::Schema.define(version: 20190708085151) do
 
   create_table "users", force: :cascade do |t|
     t.string "name"
@@ -23,6 +23,8 @@ ActiveRecord::Schema.define(version: 20190705080317) do
     t.string "activation_digest"
     t.boolean "activated", default: false
     t.datetime "activated_at"
+    t.string "reset_digest"
+    t.datetime "reset_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -18,5 +18,9 @@ FactoryBot.define do
       email { 'duchess@example.gov' }
       admin { false }
     end
+
+    trait :prepare_reset do
+      after(:create, &:create_reset_digest)
+    end
   end
 end

--- a/spec/integration/password_resets_spec.rb
+++ b/spec/integration/password_resets_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+require 'spec_helper'
+
+describe 'password resets', type: :feature do
+  let(:user) { create(:user) }
+
+  context 'when request reset password' do
+    subject { page }
+
+    before do
+      visit new_password_reset_path
+      fill_in 'Email', with: email
+      click_button 'Submit'
+    end
+
+    context 'with valid email' do
+      let(:email) { user.email }
+
+      it 'should success request' do
+        is_expected.to have_text 'Email sent with password reset instructions'
+      end
+    end
+
+    context 'with invalid email' do
+      let(:email) { '' }
+
+      it 'should fail request' do
+        is_expected.to have_text 'Email address not found'
+      end
+    end
+  end
+
+  context 'when visit reset password' do
+    subject { page }
+
+    before do
+      user.create_reset_digest
+      visit edit_password_reset_path(token, email: email)
+    end
+
+    let(:email) { user.email }
+    let(:token) { user.reset_token }
+
+    context 'with valid information' do
+      it 'should view reset password page' do
+        is_expected.to have_text 'Reset password'
+      end
+    end
+
+    context 'with invalid email' do
+      let(:email) { '' }
+
+      it_behaves_like 'should redirect root page'
+    end
+
+    context 'with not-activated user' do
+      let(:user) { create(:user, activated: false) }
+
+      it_behaves_like 'should redirect root page'
+    end
+
+    context 'with invalid token' do
+      let(:token) { 'wrong token' }
+
+      it_behaves_like 'should redirect root page'
+    end
+  end
+
+  context 'when execute reset password' do
+    subject { page }
+
+    before do
+      user.create_reset_digest
+      visit edit_password_reset_path(user.reset_token, email: user.email)
+      user.update(reset_sent_at: reset_sent_at)
+      fill_in 'Password', with: password
+      fill_in 'Confirmation', with: password_confirmation
+      click_button 'Update password'
+    end
+
+    let(:reset_sent_at) { Time.zone.now }
+
+    context 'with valid password' do
+      let(:password) { 'changed_password' }
+      let(:password_confirmation) { 'changed_password' }
+
+      it 'should view success message' do
+        is_expected.to have_text 'Password has been reset.'
+      end
+      it_behaves_like 'should state login'
+    end
+
+    context 'with invalid password confirmation' do
+      let(:password) { 'changed_password' }
+      let(:password_confirmation) { 'another_password' }
+
+      it_behaves_like 'should have any error messages'
+    end
+
+    context 'with empty password' do
+      let(:password) { '' }
+      let(:password_confirmation) { '' }
+
+      it_behaves_like 'should have any error messages'
+    end
+
+    context 'with expired token' do
+      let(:password) { 'changed_password' }
+      let(:password_confirmation) { 'changed_password' }
+      let(:reset_sent_at) { 3.hours.ago }
+
+      it_behaves_like 'should have any error messages'
+    end
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'spec_helper'
 
 describe UserMailer do
-  context 'when send activation mail' do
+  describe '#account_activation' do
     let(:user) { create(:user) }
     let(:activation_mail) { described_class.account_activation(user) }
     let(:email_subject) { 'Account activation' }
@@ -28,14 +28,12 @@ describe UserMailer do
     end
   end
 
-  context 'when send password reset mail' do
-    let(:user) { create(:user) }
+  describe '#password_reset' do
+    let(:user) { create(:user, :prepare_reset) }
     let(:password_reset_mail) { described_class.password_reset(user) }
     let(:email_subject) { 'Password reset' }
     let(:email_to) { [user.email] }
     let(:email_from) { ['noreply@example.com'] }
-
-    before { user.reset_token = User.new_token }
 
     it { expect(password_reset_mail.subject).to eq email_subject }
     it { expect(password_reset_mail.to).to eq email_to }

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -27,4 +27,22 @@ describe UserMailer do
       end
     end
   end
+
+  context 'when send password reset mail' do
+    let(:user) { create(:user) }
+    let(:password_reset_mail) { described_class.password_reset(user) }
+    let(:email_subject) { 'Password reset' }
+    let(:email_to) { [user.email] }
+    let(:email_from) { ['noreply@example.com'] }
+
+    before { user.reset_token = User.new_token }
+
+    it { expect(password_reset_mail.subject).to eq email_subject }
+    it { expect(password_reset_mail.to).to eq email_to }
+    it { expect(password_reset_mail.from).to eq email_from }
+
+    subject { password_reset_mail.body.encoded }
+    it { is_expected.to be_include(user.reset_token) }
+    it { is_expected.to be_include(CGI.escape(user.email)) }
+  end
 end

--- a/test/integration/password_resets_test.rb
+++ b/test/integration/password_resets_test.rb
@@ -1,0 +1,79 @@
+require 'test_helper'
+
+class PasswordResetsTest < ActionDispatch::IntegrationTest
+  def setup
+    ActionMailer::Base.deliveries.clear
+    @user = users(:michael)
+  end
+
+  test 'password resets' do
+    get new_password_reset_path
+    assert_template 'password_resets/new'
+
+    # メールアドレスが無効
+    post password_resets_path, params: { password_reset: { email: '' } }
+    assert_not flash.empty?
+    assert_template 'password_resets/new'
+
+    # メールアドレスが有効
+    post password_resets_path, params: { password_reset: { email: @user.email } }
+    assert_not_equal @user.reset_digest, @user.reload.reset_digest
+    assert_equal 1, ActionMailer::Base.deliveries.size
+    assert_not flash.empty?
+    assert_redirected_to root_url
+
+    # パスワード再設定フォームのテスト
+    user = assigns(:user)
+
+    # メールアドレスが無効
+    get edit_password_reset_path(user.reset_token, email: '')
+    assert_redirected_to root_url
+
+    # 無効なユーザー
+    user.update(activated: false)
+    get edit_password_reset_path(user.reset_token, email: user.email)
+    assert_redirected_to root_url
+    user.update(activated: true)
+
+    # メールアドレスが有効で、トークンが無効
+    get edit_password_reset_path('wrong token', email: user.email)
+    assert_redirected_to root_url
+
+    # メールアドレスもトークンも有効
+    get edit_password_reset_path(user.reset_token, email: user.email)
+    assert_template 'password_resets/edit'
+    assert_select 'input[name=email][type=hidden][value=?]', user.email
+
+    # 無効なパスワードとパスワード確認
+    patch password_reset_path(user.reset_token), params: {
+      email: user.email,
+      user: {
+        password: 'foobaz',
+        password_confirmation: 'barquux'
+      }
+    }
+    assert_select 'div#error_explanation'
+
+    # パスワードが空
+    patch password_reset_path(user.reset_token), params: {
+      email: user.email,
+      user: {
+        password: '',
+        password_confirmation: ''
+      }
+    }
+    assert_select 'div#error_explanation'
+
+    # 有効なパスワードとパスワード確認
+    patch password_reset_path(user.reset_token), params: {
+      email: user.email,
+      user: {
+        password: 'foobaz',
+        password_confirmation: 'foobaz'
+      }
+    }
+    assert is_logged_in?
+    assert_not flash.empty?
+    assert_redirected_to user
+  end
+end

--- a/test/integration/password_resets_test.rb
+++ b/test/integration/password_resets_test.rb
@@ -75,5 +75,25 @@ class PasswordResetsTest < ActionDispatch::IntegrationTest
     assert is_logged_in?
     assert_not flash.empty?
     assert_redirected_to user
+
+    assert_nil user.reload.reset_digest
+  end
+
+  test 'expired token' do
+    get new_password_reset_path
+    post password_resets_path, params: { password_reset: { email: @user.email } }
+
+    @user = assigns(:user)
+    @user.update(reset_sent_at: 3.hours.ago)
+    patch password_reset_path(@user.reset_token), params: {
+      email: @user.email,
+      user: {
+        password: 'foobar',
+        password_confirmation: 'foobar'
+      }
+    }
+    assert_response :redirect
+    follow_redirect!
+    assert_match(/expired/i, response.body)
   end
 end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -9,6 +9,8 @@ class UserMailerPreview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
   def password_reset
-    UserMailer.password_reset
+    user = User.first
+    user.reset_token = User.new_token
+    UserMailer.password_reset(user)
   end
 end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -12,4 +12,15 @@ class UserMailerTest < ActionMailer::TestCase
     assert_match user.activation_token, mail.body.encoded
     assert_match CGI.escape(user.email), mail.body.encoded
   end
+
+  test 'password_reset' do
+    user = users(:michael)
+    user.reset_token = User.new_token
+    mail = UserMailer.password_reset(user)
+    assert_equal 'Password reset', mail.subject
+    assert_equal [user.email], mail.to
+    assert_equal ['noreply@example.com'], mail.from
+    assert_match user.reset_token,        mail.body.encoded
+    assert_match CGI.escape(user.email),  mail.body.encoded
+  end
 end


### PR DESCRIPTION
## ストーリー

https://railstutorial.jp/chapters/password_reset?version=5.1#cha-password_reset

## 概要

パスワードの再設定機能を追加しました。

## 画面

・パスワード再設定のメールアドレス入力画面
![スクリーンショット 2019-07-09 11 08 33](https://user-images.githubusercontent.com/52316340/60854104-f6dc9e80-a239-11e9-9b93-708f1a06ab81.png)

・パスワード再設定画面
![スクリーンショット 2019-07-09 11 08 49](https://user-images.githubusercontent.com/52316340/60854105-f7753500-a239-11e9-8b74-ca0285ec2497.png)

## 仕様・注意事項

変更点
・Herokuデプロイ→手元macで動作確認

飛ばした箇所
・12.4 本番環境でのメール送信 (再掲)：メールサーバーの設定が必要であるため

## 見どころ

・RSpecを重点的にお願いします。